### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ russian-tagsets
 
 .. _OpenCorpora: http://opencorpora.org/dict.php?act=gram
 .. _aot.ru: http://aot.ru/docs/rusmorph.html
-.. _pymorphy: http://pymorphy.readthedocs.org/en/v0.5.6/ref/gram_info_ru.html
+.. _pymorphy: https://pymorphy.readthedocs.io/en/v0.5.6/ref/gram_info_ru.html
 .. _pymorphy2: https://github.com/kmike/pymorphy2
 .. _Диалог-2010: http://ru-eval.ru/
 .. _A Positional Tagset for Russian: http://ufal.mff.cuni.cz/~hana/morph/rutags.html


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
