### PR TITLE
Fix error while python 3.5 installation on Windows.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,8 @@ from distutils.core import setup
 
 __version__ = '0.5.2'
 
+"Используем utf-8"
+
 setup(
     name="russian-tagsets",
     version=__version__,

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 #! /usr/bin/env python
+import platform
 from distutils.core import setup
 
 try:
@@ -7,8 +8,9 @@ except ImportError:
     __pypy__ = None
 
 __version__ = '0.5.2'
+py2 = int(platform.python_version_tuple()) == 2
 
-if __pypy__:
+if __pypy__ or py2:
     ld1 = open('README.rst').read()
     ld2 = open('CHANGES.rst').read()
 else:

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ except ImportError:
     __pypy__ = None
 
 __version__ = '0.5.2'
-py2 = int(platform.python_version_tuple()) == 2
+py2 = int(platform.python_version_tuple()[0]) == 2
 
 if __pypy__ or py2:
     ld1 = open('README.rst').read()

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,25 @@
 #! /usr/bin/env python
 from distutils.core import setup
 
+try:
+    import __pypy__
+except ImportError:
+    __pypy__ = None
+
 __version__ = '0.5.2'
+
+if __pypy__:
+    ld1 = open('README.rst').read()
+    ld2 = open('CHANGES.rst').read()
+else:
+    ld1 = open('README.rst', encoding='utf-8').read()
+    ld2 = open('CHANGES.rst', encoding='utf-8').read()
 
 setup(
     name="russian-tagsets",
     version=__version__,
     description="Russian tagset converters library",
-    long_description = open('README.rst', encoding='utf-8').read() + "\n\n" + open('CHANGES.rst', encoding='utf-8').read(),
+    long_description = ld1 + "\n\n" + ld2,
     license = 'MIT license',
     author='Mikhail Korobov',
     author_email='kmike84@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -5,11 +5,14 @@ __version__ = '0.5.2'
 
 "Используем utf-8"
 
+r1 = open('README.rst', encoding='utf8').read()
+r2 = open('CHANGES.rst', encoding='utf8').read()
+
 setup(
     name="russian-tagsets",
     version=__version__,
     description="Russian tagset converters library",
-    long_description = open('README.rst').read() + "\n\n" + open('CHANGES.rst').read(),
+    long_description = r1 + "\n\n" + r2,
     license = 'MIT license',
     author='Mikhail Korobov',
     author_email='kmike84@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,11 @@
 #! /usr/bin/env python
-import platform
+import sys
 from distutils.core import setup
 
-try:
-    import __pypy__
-except ImportError:
-    __pypy__ = None
-
 __version__ = '0.5.2'
-py2 = int(platform.python_version_tuple()[0]) == 2
+PY2 = sys.version_info[0] == 2
 
-if __pypy__ or py2:
+if PY2:
     ld1 = open('README.rst').read()
     ld2 = open('CHANGES.rst').read()
 else:

--- a/setup.py
+++ b/setup.py
@@ -5,14 +5,11 @@ __version__ = '0.5.2'
 
 "Используем utf-8"
 
-r1 = open('README.rst', encoding='utf8').read()
-r2 = open('CHANGES.rst', encoding='utf8').read()
-
 setup(
     name="russian-tagsets",
     version=__version__,
     description="Russian tagset converters library",
-    long_description = r1 + "\n\n" + r2,
+    long_description = open('README.rst', encoding='utf-8').read() + "\n\n" + open('CHANGES.rst', encoding='utf-8').read(),
     license = 'MIT license',
     author='Mikhail Korobov',
     author_email='kmike84@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,6 @@ from distutils.core import setup
 
 __version__ = '0.5.2'
 
-"Используем utf-8"
-
 setup(
     name="russian-tagsets",
     version=__version__,


### PR DESCRIPTION
When I tried to install this library, there was an error. Python tried to decode README.rst as cp1251. This PR fixes the bug.